### PR TITLE
Support for URLs with HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ FFMpeg::open('steve_howe.mp4')
     });
 ```
 
+### Open files from the web
+
+You can open files from the web by using the `openUrl` method. You can specify custom HTTP headers with the optional second parameter:
+
+```php
+FFMpeg::openUrl('https://videocoursebuilder.com/lesson-1.mp4');
+
+FFMpeg::openUrl('https://videocoursebuilder.com/lesson-2.mp4', [
+    'Authorization' => 'Basic YWRtaW46MTIzNA==',
+]);
+```
+
 ### Filters
 
 You can add filters through a ```Closure``` or by using PHP-FFMpeg's Filter objects:
@@ -331,6 +343,15 @@ FFMpeg::open(['video.mp4', 'video2.mp4'])
     ->addFilter(function(ComplexFilters $filters) {
         // $filters->watermark(...);
     });
+```
+
+Opening files from the web works similarly. You can pass an array of URLs to the `openUrl` method:
+
+```php
+FFMpeg::openUrl([
+    'https://videocoursebuilder.com/lesson-3.mp4',
+    'https://videocoursebuilder.com/lesson-4.mp4',
+]);
 ```
 
 ### Concat files without transcoding

--- a/README.md
+++ b/README.md
@@ -345,12 +345,29 @@ FFMpeg::open(['video.mp4', 'video2.mp4'])
     });
 ```
 
-Opening files from the web works similarly. You can pass an array of URLs to the `openUrl` method:
+Opening files from the web works similarly. You can pass an array of URLs to the `openUrl` method, optionally with custom HTTP headers.
 
 ```php
 FFMpeg::openUrl([
     'https://videocoursebuilder.com/lesson-3.mp4',
     'https://videocoursebuilder.com/lesson-4.mp4',
+]);
+
+FFMpeg::openUrl([
+    'https://videocoursebuilder.com/lesson-3.mp4',
+    'https://videocoursebuilder.com/lesson-4.mp4',
+], [
+    'Authorization' => 'Basic YWRtaW46MTIzNA==',
+]);
+```
+
+If you want to use another set of HTTP headers for each URL, you can chain the `openUrl` method:
+
+```php
+FFMpeg::openUrl('https://videocoursebuilder.com/lesson-5.mp4', [
+    'Authorization' => 'Basic YWRtaW46MTIzNA==',
+])->openUrl('https://videocoursebuilder.com/lesson-6.mp4', [
+    'Authorization' => 'Basic bmltZGE6NDMyMQ==',
 ]);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "evenement/evenement": "^2.0 || ^3.0",
+        "evenement/evenement": "^3.0",
         "illuminate/bus": "^6.0|^7.0|^8.0",
         "illuminate/config": "^6.0|^7.0|^8.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0",

--- a/src/Drivers/PHPFFMpeg.php
+++ b/src/Drivers/PHPFFMpeg.php
@@ -10,16 +10,22 @@ use FFMpeg\FFProbe\DataMapping\Stream;
 use FFMpeg\Filters\Audio\SimpleFilter;
 use FFMpeg\Filters\FilterInterface;
 use FFMpeg\Media\AbstractMediaType;
-use FFMpeg\Media\AdvancedMedia;
+use FFMpeg\Media\AdvancedMedia as BaseAdvancedMedia;
 use FFMpeg\Media\Concat;
 use FFMpeg\Media\Frame;
 use FFMpeg\Media\Video;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
+use ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\AdvancedMedia;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\AudioMedia;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\FFProbe;
 use ProtoneMedia\LaravelFFMpeg\FFMpeg\LegacyFilterMapping;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\VideoMedia;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork;
 
 /**
  * @mixin \FFMpeg\Media\AbstractMediaType
@@ -74,7 +80,7 @@ class PHPFFMpeg
 
     private function isAdvancedMedia(): bool
     {
-        return $this->get() instanceof AdvancedMedia;
+        return $this->get() instanceof BaseAdvancedMedia;
     }
 
     public function isFrame(): bool
@@ -108,12 +114,28 @@ class PHPFFMpeg
 
         $this->mediaCollection = $mediaCollection;
 
-        $localPaths = $mediaCollection->getLocalPaths();
+        if ($mediaCollection->count() === 1 && !$this->forceAdvanced) {
+            $packageMedia = Arr::first($mediaCollection->collection());
 
-        if (count($localPaths) === 1 && !$this->forceAdvanced) {
-            $this->media = $this->ffmpeg->open(Arr::first($localPaths));
+            $this->ffmpeg->setFFProbe(
+                FFProbe::make($this->ffmpeg->getFFProbe())->setMedia($packageMedia)
+            );
+
+            $media = $this->ffmpeg->open($packageMedia->getLocalPath());
+
+            $this->media = $media instanceof Video
+                ? VideoMedia::make($media)
+                : AudioMedia::make($media);
+
+            if ($packageMedia instanceof MediaOnNetwork) {
+                $this->media->setHeaders($packageMedia->getHeaders());
+            }
         } else {
-            $this->media = $this->ffmpeg->openAdvanced($localPaths);
+            $localPaths = $mediaCollection->getLocalPaths();
+
+            $this->media = AdvancedMedia::make(
+                $this->ffmpeg->openAdvanced($localPaths)
+            );
         }
 
         return $this;

--- a/src/Drivers/PHPFFMpeg.php
+++ b/src/Drivers/PHPFFMpeg.php
@@ -126,7 +126,7 @@ class PHPFFMpeg
                 ? VideoMedia::make($ffmpegMedia)
                 : AudioMedia::make($ffmpegMedia);
 
-            $this->media->setHeaders(Arr::first($mediaCollection->getHeaders()));
+            $this->media->setHeaders(Arr::first($mediaCollection->getHeaders()) ?: []);
         } else {
             $ffmpegMedia = $this->ffmpeg->openAdvanced($mediaCollection->getLocalPaths());
 

--- a/src/FFMpeg/AdvancedMedia.php
+++ b/src/FFMpeg/AdvancedMedia.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use FFMpeg\Media\AdvancedMedia as MediaAdvancedMedia;
+
+class AdvancedMedia extends MediaAdvancedMedia
+{
+    public static function make(MediaAdvancedMedia $media)
+    {
+        return new static($media->getInputs(), $media->getFFMpegDriver(), FFProbe::make($media->getFFProbe()));
+    }
+}

--- a/src/FFMpeg/AdvancedMedia.php
+++ b/src/FFMpeg/AdvancedMedia.php
@@ -6,8 +6,34 @@ use FFMpeg\Media\AdvancedMedia as MediaAdvancedMedia;
 
 class AdvancedMedia extends MediaAdvancedMedia
 {
+    use InteractsWithHttpHeaders;
+
     public static function make(MediaAdvancedMedia $media)
     {
         return new static($media->getInputs(), $media->getFFMpegDriver(), FFProbe::make($media->getFFProbe()));
+    }
+
+    /**
+     * @return array
+     */
+    protected function buildCommand()
+    {
+        $command = parent::buildCommand();
+
+        $inputKey = array_search($this->getPathfile(), $command) - 1;
+
+        foreach ($this->getInputs() as $inputKey => $path) {
+            $headers = $this->headers[$inputKey];
+            $inputKey += 2;
+
+            if (empty($headers)) {
+                continue;
+            }
+
+            $command = static::mergeBeforePathInput($command, $path, static::compileHeaders($headers));
+            $inputKey += 2;
+        }
+
+        return $command;
     }
 }

--- a/src/FFMpeg/AdvancedMedia.php
+++ b/src/FFMpeg/AdvancedMedia.php
@@ -3,6 +3,7 @@
 namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
 
 use FFMpeg\Media\AdvancedMedia as MediaAdvancedMedia;
+use Illuminate\Support\Arr;
 
 class AdvancedMedia extends MediaAdvancedMedia
 {
@@ -20,18 +21,18 @@ class AdvancedMedia extends MediaAdvancedMedia
     {
         $command = parent::buildCommand();
 
-        $inputKey = array_search($this->getPathfile(), $command) - 1;
+        $inputKey = array_search(Arr::first($this->getInputs()), $command) - 1;
 
-        foreach ($this->getInputs() as $inputKey => $path) {
-            $headers = $this->headers[$inputKey];
-            $inputKey += 2;
+        foreach ($this->getInputs() as $key => $path) {
+            $headers = $this->headers[$key];
 
             if (empty($headers)) {
+                $inputKey += 2;
                 continue;
             }
 
-            $command = static::mergeBeforePathInput($command, $path, static::compileHeaders($headers));
-            $inputKey += 2;
+            $command = static::mergeBeforeKey($command, $inputKey, static::compileHeaders($headers));
+            $inputKey += 4;
         }
 
         return $command;

--- a/src/FFMpeg/AdvancedMedia.php
+++ b/src/FFMpeg/AdvancedMedia.php
@@ -9,12 +9,21 @@ class AdvancedMedia extends MediaAdvancedMedia
 {
     use InteractsWithHttpHeaders;
 
-    public static function make(MediaAdvancedMedia $media)
+    /**
+     * Create a new instance of this class with the instance of the underlying library.
+     *
+     * @param \FFMpeg\Media\AdvancedMedia $media
+     * @return self
+     */
+    public static function make(MediaAdvancedMedia $media): self
     {
         return new static($media->getInputs(), $media->getFFMpegDriver(), FFProbe::make($media->getFFProbe()));
     }
 
     /**
+     * Builds the command using the underlying library and then
+     * prepends every input with its own set of headers.
+     *
      * @return array
      */
     protected function buildCommand()

--- a/src/FFMpeg/AudioMedia.php
+++ b/src/FFMpeg/AudioMedia.php
@@ -6,7 +6,7 @@ use FFMpeg\Media\Audio;
 
 class AudioMedia extends Audio
 {
-    use InteractsWithHttpHeaders;
+    use BuildsCommandsWithHttpHeaders;
 
     public static function make(Audio $audio)
     {

--- a/src/FFMpeg/AudioMedia.php
+++ b/src/FFMpeg/AudioMedia.php
@@ -8,7 +8,13 @@ class AudioMedia extends Audio
 {
     use BuildsCommandsWithHttpHeaders;
 
-    public static function make(Audio $audio)
+    /**
+     * Create a new instance of this class with the instance of the underlying library.
+     *
+     * @param \FFMpeg\Media\Audio $audio
+     * @return self
+     */
+    public static function make(Audio $audio): self
     {
         return new static($audio->getPathfile(), $audio->getFFMpegDriver(), FFProbe::make($audio->getFFProbe()));
     }

--- a/src/FFMpeg/AudioMedia.php
+++ b/src/FFMpeg/AudioMedia.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use FFMpeg\Media\Audio;
+
+class AudioMedia extends Audio
+{
+    use InteractsWithHttpHeaders;
+
+    public static function make(Audio $audio)
+    {
+        return new static($audio->getPathfile(), $audio->getFFMpegDriver(), FFProbe::make($audio->getFFProbe()));
+    }
+}

--- a/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
+++ b/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use FFMpeg\Format\FormatInterface;
+use Illuminate\Support\Collection;
+
+trait BuildsCommandsWithHttpHeaders
+{
+    use InteractsWithHttpHeaders;
+
+    protected function buildCommand(FormatInterface $format, $outputPathfile)
+    {
+        $command = parent::buildCommand($format, $outputPathfile);
+
+        if (empty($this->headers)) {
+            return $command;
+        }
+
+        return Collection::make($command)->map(function ($command, $pass) {
+            return static::mergeBeforePathInput(
+                $command,
+                $this->getPathfile(),
+                static::compileHeaders($this->headers)
+            );
+        })->all();
+    }
+}

--- a/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
+++ b/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
@@ -9,6 +9,14 @@ trait BuildsCommandsWithHttpHeaders
 {
     use InteractsWithHttpHeaders;
 
+    /**
+     * Builds the command using the underlying library and then
+     * prepends the input with the headers.
+     *
+     * @param \FFMpeg\Format\FormatInterface $format
+     * @param string $outputPathfile
+     * @return array
+     */
     protected function buildCommand(FormatInterface $format, $outputPathfile)
     {
         $command = parent::buildCommand($format, $outputPathfile);

--- a/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
+++ b/src/FFMpeg/BuildsCommandsWithHttpHeaders.php
@@ -17,7 +17,7 @@ trait BuildsCommandsWithHttpHeaders
             return $command;
         }
 
-        return Collection::make($command)->map(function ($command, $pass) {
+        return Collection::make($command)->map(function ($command) {
             return static::mergeBeforePathInput(
                 $command,
                 $this->getPathfile(),

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use FFMpeg\Exception\RuntimeException;
+use FFMpeg\FFProbe as FFMpegFFProbe;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork;
+
+class FFProbe extends FFMpegFFProbe
+{
+    protected $media;
+
+    public static function make(FFMpegFFProbe $probe): self
+    {
+        if ($probe instanceof FFProbe) {
+            return $probe;
+        }
+
+        return new static($probe->getFFProbeDriver(), $probe->getCache());
+    }
+
+    public function setMedia($media): self
+    {
+        $this->media = $media;
+
+        return $this;
+    }
+
+    public function streams($pathfile)
+    {
+        if (!$this->media instanceof MediaOnNetwork || $this->media->getLocalPath() !== $pathfile) {
+            return parent::streams($pathfile);
+        }
+
+        if (!$this->getOptionsTester()->has('-show_streams')) {
+            throw new RuntimeException('This version of ffprobe is too old and does not support `-show_streams` option, please upgrade');
+        }
+
+        return $this->probeStreams($pathfile);
+    }
+
+    /**
+     * This is just copy-paste from FFMpeg\FFProbe...
+     */
+    private function probeStreams($pathfile, $allowJson = true)
+    {
+        $commands = array_merge(
+            $this->media->getCompiledHeaders(),
+            [$pathfile, '-show_streams']
+        );
+
+        $parseIsToDo = false;
+
+        if ($allowJson && $this->getOptionsTester()->has('-print_format')) {
+            // allowed in latest PHP-FFmpeg version
+            $commands[] = '-print_format';
+            $commands[] = 'json';
+        } elseif ($allowJson && $this->getOptionsTester()->has('-of')) {
+            // option has changed in avconv 9
+            $commands[] = '-of';
+            $commands[] = 'json';
+        } else {
+            $parseIsToDo = true;
+        }
+
+        try {
+            $output = $this->getFFProbeDriver()->command($commands);
+        } catch (ExecutionFailureException $e) {
+            throw new RuntimeException(sprintf('Unable to probe %s', $pathfile), $e->getCode(), $e);
+        }
+
+        if ($parseIsToDo) {
+            $data = $this->getParser()->parse(static::TYPE_STREAMS, $output);
+        } else {
+            try {
+                $data = @json_decode($output, true);
+
+                if (JSON_ERROR_NONE !== json_last_error()) {
+                    throw new RuntimeException(sprintf('Unable to parse json %s', $output));
+                }
+            } catch (RuntimeException $e) {
+                return $this->probeStreams($pathfile, false);
+            }
+        }
+
+        return $this->getMapper()->map(static::TYPE_STREAMS, $data);
+    }
+}

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -9,8 +9,24 @@ use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork;
 
 class FFProbe extends FFMpegFFProbe
 {
+    /**
+     * @var \ProtoneMedia\LaravelFFMpeg\Filesystem\Media|\ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork
+     */
     protected $media;
 
+    public function setMedia($media): self
+    {
+        $this->media = $media;
+
+        return $this;
+    }
+
+    /**
+     * Create a new instance of this class with the instance of the underlying library.
+     *
+     * @param \FFMpeg\FFProbe $probe
+     * @return self
+     */
     public static function make(FFMpegFFProbe $probe): self
     {
         if ($probe instanceof FFProbe) {
@@ -20,12 +36,14 @@ class FFProbe extends FFMpegFFProbe
         return new static($probe->getFFProbeDriver(), $probe->getCache());
     }
 
-    public function setMedia($media): self
-    {
-        $this->media = $media;
-
-        return $this;
-    }
+    /**
+     * Probes the streams contained in a given file.
+     *
+     * @param string $pathfile
+     * @return \FFMpeg\FFProbe\DataMapping\StreamCollection
+     * @throws \FFMpeg\Exception\InvalidArgumentException
+     * @throws \FFMpeg\Exception\RuntimeException
+     */
 
     public function streams($pathfile)
     {
@@ -42,6 +60,7 @@ class FFProbe extends FFMpegFFProbe
 
     /**
      * This is just copy-paste from FFMpeg\FFProbe...
+     * It prepends the command with the headers.
      */
     private function probeStreams($pathfile, $allowJson = true)
     {

--- a/src/FFMpeg/InteractsWithHttpHeaders.php
+++ b/src/FFMpeg/InteractsWithHttpHeaders.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use FFMpeg\Format\FormatInterface;
+use Illuminate\Support\Collection;
+
+trait InteractsWithHttpHeaders
+{
+    protected $headers = [];
+
+    public function setHeaders(array $headers = []): self
+    {
+        $this->headers = $headers;
+
+        return $this;
+    }
+
+    protected function buildCommand(FormatInterface $format, $outputPathfile)
+    {
+        $command = parent::buildCommand($format, $outputPathfile);
+
+        if (empty($this->headers)) {
+            return $command;
+        }
+
+        return Collection::make($command)->map(function ($command, $pass) {
+            $inputKey = array_search($this->getPathfile(), $command) - 1;
+
+            $first = array_slice($command, 0, $inputKey);
+            $last = array_slice($command, $inputKey);
+
+            return array_merge($first, static::compileHeaders($this->headers), $last);
+        })->all();
+    }
+
+    public static function compileHeaders(array $headers = []): array
+    {
+        if (empty($headers)) {
+            return [];
+        }
+
+        $headers = Collection::make($headers)->map(function ($value, $key) {
+            return "{$key}: {$value}";
+        })->filter()->push("")->implode("\r\n");
+
+        return [
+            '-headers',
+            $headers,
+        ];
+    }
+}

--- a/src/FFMpeg/InteractsWithHttpHeaders.php
+++ b/src/FFMpeg/InteractsWithHttpHeaders.php
@@ -6,6 +6,9 @@ use Illuminate\Support\Collection;
 
 trait InteractsWithHttpHeaders
 {
+    /**
+     * @var array
+     */
     protected $headers = [];
 
     public function getHeaders(): array
@@ -20,6 +23,15 @@ trait InteractsWithHttpHeaders
         return $this;
     }
 
+    /**
+     * Searches in the $input array for the key bu the $path, and then
+     * prepend the $values in front of that key.
+     *
+     * @param array $input
+     * @param string $path
+     * @param array $values
+     * @return array
+     */
     protected static function mergeBeforePathInput(array $input, string $path, array $values = []): array
     {
         $key = array_search($path, $input) - 1;
@@ -27,6 +39,14 @@ trait InteractsWithHttpHeaders
         return static::mergeBeforeKey($input, $key, $values);
     }
 
+    /**
+     * Prepend the given $values in front of the $key in $input.
+     *
+     * @param array $input
+     * @param integer $key
+     * @param array $values
+     * @return array
+     */
     protected static function mergeBeforeKey(array $input, int $key, array $values = []): array
     {
         return array_merge(
@@ -36,6 +56,13 @@ trait InteractsWithHttpHeaders
         );
     }
 
+    /**
+     * Maps the headers into a key-value string for FFmpeg. Returns
+     * an array of arguments to pass into the command.
+     *
+     * @param array $headers
+     * @return array
+     */
     public static function compileHeaders(array $headers = []): array
     {
         if (empty($headers)) {

--- a/src/FFMpeg/InteractsWithHttpHeaders.php
+++ b/src/FFMpeg/InteractsWithHttpHeaders.php
@@ -24,6 +24,11 @@ trait InteractsWithHttpHeaders
     {
         $key = array_search($path, $input) - 1;
 
+        return static::mergeBeforeKey($input, $key, $values);
+    }
+
+    protected static function mergeBeforeKey(array $input, int $key, array $values = []): array
+    {
         return array_merge(
             array_slice($input, 0, $key),
             $values,

--- a/src/FFMpeg/VideoMedia.php
+++ b/src/FFMpeg/VideoMedia.php
@@ -8,7 +8,13 @@ class VideoMedia extends Video
 {
     use BuildsCommandsWithHttpHeaders;
 
-    public static function make(Video $video)
+    /**
+     * Create a new instance of this class with the instance of the underlying library.
+     *
+     * @param \FFMpeg\Media\Video $video
+     * @return self
+     */
+    public static function make(Video $video): self
     {
         return new static($video->getPathfile(), $video->getFFMpegDriver(), $video->getFFProbe());
     }

--- a/src/FFMpeg/VideoMedia.php
+++ b/src/FFMpeg/VideoMedia.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
+
+use FFMpeg\Media\Video;
+
+class VideoMedia extends Video
+{
+    use InteractsWithHttpHeaders;
+
+    public static function make(Video $video)
+    {
+        return new static($video->getPathfile(), $video->getFFMpegDriver(), $video->getFFProbe());
+    }
+}

--- a/src/FFMpeg/VideoMedia.php
+++ b/src/FFMpeg/VideoMedia.php
@@ -6,7 +6,7 @@ use FFMpeg\Media\Video;
 
 class VideoMedia extends Video
 {
-    use InteractsWithHttpHeaders;
+    use BuildsCommandsWithHttpHeaders;
 
     public static function make(Video $video)
     {

--- a/src/Filesystem/MediaCollection.php
+++ b/src/Filesystem/MediaCollection.php
@@ -35,6 +35,16 @@ class MediaCollection
         return $this->items->map->getLocalPath()->all();
     }
 
+    /**
+     * Returns an array with all headers of the Media items.
+     */
+    public function getHeaders(): array
+    {
+        return $this->items->map(function ($media) {
+            return $media instanceof MediaOnNetwork ? $media->getHeaders() : [];
+        })->all();
+    }
+
     public function collection(): Collection
     {
         return $this->items;

--- a/src/Filesystem/MediaCollection.php
+++ b/src/Filesystem/MediaCollection.php
@@ -40,6 +40,11 @@ class MediaCollection
         return $this->items;
     }
 
+    public function count(): int
+    {
+        return $this->items->count();
+    }
+
     public function __call($method, $parameters)
     {
         return $this->forwardCallTo($this->collection(), $method, $parameters);

--- a/src/Filesystem/MediaCollection.php
+++ b/src/Filesystem/MediaCollection.php
@@ -50,6 +50,11 @@ class MediaCollection
         return $this->items;
     }
 
+    /**
+     * Count the number of items in the collection.
+     *
+     * @return int
+     */
     public function count(): int
     {
         return $this->items->count();

--- a/src/Filesystem/MediaOnNetwork.php
+++ b/src/Filesystem/MediaOnNetwork.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\Filesystem;
+
+class MediaOnNetwork
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    public function __construct(string $path)
+    {
+        $this->path = $path;
+    }
+
+    public static function make(string $path): self
+    {
+        return new static($path);
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getDisk(): Disk
+    {
+        return Disk::make(config('filesystems.default'));
+    }
+
+    public function getLocalPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getFilenameWithoutExtension(): string
+    {
+        return pathinfo($this->getPath())['filename'];
+    }
+
+    public function getFilename(): string
+    {
+        return pathinfo($this->getPath())['basename'];
+    }
+}

--- a/src/Filesystem/MediaOnNetwork.php
+++ b/src/Filesystem/MediaOnNetwork.php
@@ -2,6 +2,8 @@
 
 namespace ProtoneMedia\LaravelFFMpeg\Filesystem;
 
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\AudioMedia;
+
 class MediaOnNetwork
 {
     /**
@@ -9,14 +11,20 @@ class MediaOnNetwork
      */
     private $path;
 
-    public function __construct(string $path)
+    /**
+     * @var array
+     */
+    private $headers = [];
+
+    public function __construct(string $path, array $headers = [])
     {
-        $this->path = $path;
+        $this->path    = $path;
+        $this->headers = $headers;
     }
 
-    public static function make(string $path): self
+    public static function make(string $path, array $headers = []): self
     {
-        return new static($path);
+        return new static($path, $headers);
     }
 
     public function getPath(): string
@@ -42,5 +50,15 @@ class MediaOnNetwork
     public function getFilename(): string
     {
         return pathinfo($this->getPath())['basename'];
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getCompiledHeaders(): array
+    {
+        return AudioMedia::compileHeaders($this->getHeaders());
     }
 }

--- a/src/Filesystem/MediaOnNetwork.php
+++ b/src/Filesystem/MediaOnNetwork.php
@@ -2,19 +2,16 @@
 
 namespace ProtoneMedia\LaravelFFMpeg\Filesystem;
 
-use ProtoneMedia\LaravelFFMpeg\FFMpeg\AudioMedia;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\InteractsWithHttpHeaders;
 
 class MediaOnNetwork
 {
+    use InteractsWithHttpHeaders;
+
     /**
      * @var string
      */
     private $path;
-
-    /**
-     * @var array
-     */
-    private $headers = [];
 
     public function __construct(string $path, array $headers = [])
     {
@@ -52,13 +49,8 @@ class MediaOnNetwork
         return pathinfo($this->getPath())['basename'];
     }
 
-    public function getHeaders(): array
-    {
-        return $this->headers;
-    }
-
     public function getCompiledHeaders(): array
     {
-        return AudioMedia::compileHeaders($this->getHeaders());
+        return static::compileHeaders($this->getHeaders());
     }
 }

--- a/src/MediaOpener.php
+++ b/src/MediaOpener.php
@@ -88,9 +88,9 @@ class MediaOpener
     /**
      * Instantiates a Media object for each given path.
      */
-    public function open($path): self
+    public function open($paths): self
     {
-        foreach (Arr::wrap($path) as $path) {
+        foreach (Arr::wrap($paths) as $path) {
             $this->collection->push(Media::make($this->disk, $path));
         }
 
@@ -100,9 +100,9 @@ class MediaOpener
     /**
      * Instantiates a MediaOnNetwork object for each given url.
      */
-    public function openUrl($path, array $headers = []): self
+    public function openUrl($paths, array $headers = []): self
     {
-        foreach (Arr::wrap($path) as $path) {
+        foreach (Arr::wrap($paths) as $path) {
             $this->collection->push(MediaOnNetwork::make($path, $headers));
         }
 

--- a/src/MediaOpener.php
+++ b/src/MediaOpener.php
@@ -97,6 +97,9 @@ class MediaOpener
         return $this;
     }
 
+    /**
+     * Instantiates a MediaOnNetwork object for each given url.
+     */
     public function openUrl($path, array $headers = []): self
     {
         foreach (Arr::wrap($path) as $path) {

--- a/src/MediaOpener.php
+++ b/src/MediaOpener.php
@@ -90,9 +90,7 @@ class MediaOpener
      */
     public function open($path): self
     {
-        $paths = Arr::wrap($path);
-
-        foreach ($paths as $path) {
+        foreach (Arr::wrap($path) as $path) {
             $this->collection->push(Media::make($this->disk, $path));
         }
 
@@ -101,9 +99,7 @@ class MediaOpener
 
     public function openUrl($path, array $headers = []): self
     {
-        $paths = Arr::wrap($path);
-
-        foreach ($paths as $path) {
+        foreach (Arr::wrap($path) as $path) {
             $this->collection->push(MediaOnNetwork::make($path, $headers));
         }
 

--- a/src/MediaOpener.php
+++ b/src/MediaOpener.php
@@ -14,6 +14,7 @@ use ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Disk;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\TemporaryDirectories;
 
 /**
@@ -93,6 +94,17 @@ class MediaOpener
 
         foreach ($paths as $path) {
             $this->collection->push(Media::make($this->disk, $path));
+        }
+
+        return $this;
+    }
+
+    public function openUrl($path): self
+    {
+        $paths = Arr::wrap($path);
+
+        foreach ($paths as $path) {
+            $this->collection->push(MediaOnNetwork::make($path));
         }
 
         return $this;

--- a/src/MediaOpener.php
+++ b/src/MediaOpener.php
@@ -99,12 +99,12 @@ class MediaOpener
         return $this;
     }
 
-    public function openUrl($path): self
+    public function openUrl($path, array $headers = []): self
     {
         $paths = Arr::wrap($path);
 
         foreach ($paths as $path) {
-            $this->collection->push(MediaOnNetwork::make($path));
+            $this->collection->push(MediaOnNetwork::make($path, $headers));
         }
 
         return $this;

--- a/src/Support/FFMpeg.php
+++ b/src/Support/FFMpeg.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener fromDisk($disk)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener fromFilesystem(\Illuminate\Contracts\Filesystem\Filesystem $filesystem)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener open($path)
+ * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener openUrl($path)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener cleanupTemporaryFiles()
  *
  * @see \ProtoneMedia\LaravelFFMpeg\MediaOpener

--- a/src/Support/FFMpeg.php
+++ b/src/Support/FFMpeg.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener fromDisk($disk)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener fromFilesystem(\Illuminate\Contracts\Filesystem\Filesystem $filesystem)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener open($path)
- * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener openUrl($path)
+ * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener openUrl($path, array $headers)
  * @method static \ProtoneMedia\LaravelFFMpeg\MediaOpener cleanupTemporaryFiles()
  *
  * @see \ProtoneMedia\LaravelFFMpeg\MediaOpener

--- a/src/Support/MediaOpenerFactory.php
+++ b/src/Support/MediaOpenerFactory.php
@@ -19,6 +19,11 @@ class MediaOpenerFactory
         $this->driver      = $driver;
     }
 
+    public function new(): MediaOpener
+    {
+        return new MediaOpener($this->defaultDisk, $this->driver);
+    }
+
     /**
     * Handle dynamic method calls into the MediaOpener.
     *
@@ -28,10 +33,6 @@ class MediaOpenerFactory
     */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo(
-            new MediaOpener($this->defaultDisk, $this->driver),
-            $method,
-            $parameters
-        );
+        return $this->forwardCallTo($this->new(), $method, $parameters);
     }
 }

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -27,6 +27,20 @@ class ExportTest extends TestCase
 
         $this->assertTrue(Storage::disk('local')->has('new_video.mp4'));
     }
+
+    /** @test */
+    public function it_can_export_a_single_remote_video_file()
+    {
+        $this->fakeLocalVideoFile();
+
+        FFMpeg::openUrl('https://raw.githubusercontent.com/protonemedia/laravel-ffmpeg/master/tests/src/video.mp4')
+            ->export()
+            ->inFormat($this->x264())
+            ->save('new_video.mp4');
+
+        $this->assertTrue(Storage::disk('local')->has('new_video.mp4'));
+    }
+
     /** @test */
     public function it_can_export_a_single_audio_file()
     {

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -237,6 +237,29 @@ class ExportTest extends TestCase
     }
 
     /** @test */
+    public function it_can_merge_two_remote_video_files_with_different_headers()
+    {
+        $this->fakeLocalVideoFile();
+
+        FFMpeg::openUrl('https://ffmpeg.protone.media/video.mp4', [
+            'Authorization' => 'Basic YWRtaW46MTIzNA==',
+        ])->openUrl('https://ffmpeg.protone.media/video2.mp4', [
+            'Authorization' => 'Basic YWRtaW46NDMyMQ==',
+        ])
+            ->export()
+            ->addFilter('[0:v][1:v]', 'hstack', '[v]')
+            ->addFormatOutputMapping($this->x264(), Media::make('local', 'new_video.mp4'), ['[v]'])
+            ->save();
+
+        $this->assertTrue(Storage::disk('local')->has('new_video.mp4'));
+
+        $this->assertEquals(
+            3840,
+            (new MediaOpener)->fromDisk('local')->open('new_video.mp4')->getStreams()[0]->get('width')
+        );
+    }
+
+    /** @test */
     public function it_can_stack_two_videos_horizontally()
     {
         $this->fakeLocalVideoFiles();

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -237,15 +237,40 @@ class ExportTest extends TestCase
     }
 
     /** @test */
+    public function it_can_merge_two_remote_video_files_with_the_same_headers()
+    {
+        $this->fakeLocalVideoFile();
+
+        FFMpeg::openUrl([
+            'https://ffmpeg.protone.media/video.mp4',
+            'https://ffmpeg.protone.media/video.mp4',
+        ], [
+            'Authorization' => 'Basic YWRtaW46MTIzNA==',
+        ])
+            ->export()
+            ->addFilter('[0:v][1:v]', 'hstack', '[v]')
+            ->addFormatOutputMapping($this->x264(), Media::make('local', 'new_video.mp4'), ['[v]'])
+            ->save();
+
+        $this->assertTrue(Storage::disk('local')->has('new_video.mp4'));
+
+        $this->assertEquals(
+            3840,
+            (new MediaOpener)->fromDisk('local')->open('new_video.mp4')->getStreams()[0]->get('width')
+        );
+    }
+
+    /** @test */
     public function it_can_merge_two_remote_video_files_with_different_headers()
     {
         $this->fakeLocalVideoFile();
 
-        FFMpeg::openUrl('https://ffmpeg.protone.media/video.mp4', [
-            'Authorization' => 'Basic YWRtaW46MTIzNA==',
-        ])->openUrl('https://ffmpeg.protone.media/video2.mp4', [
-            'Authorization' => 'Basic YWRtaW46NDMyMQ==',
-        ])
+        FFMpeg::new()
+            ->openUrl('https://ffmpeg.protone.media/video.mp4', [
+                'Authorization' => 'Basic YWRtaW46MTIzNA==',
+            ])->openUrl('https://ffmpeg.protone.media/video2.mp4', [
+                'Authorization' => 'Basic YWRtaW46NDMyMQ==',
+            ])
             ->export()
             ->addFilter('[0:v][1:v]', 'hstack', '[v]')
             ->addFormatOutputMapping($this->x264(), Media::make('local', 'new_video.mp4'), ['[v]'])

--- a/tests/ExportTest.php
+++ b/tests/ExportTest.php
@@ -33,7 +33,9 @@ class ExportTest extends TestCase
     {
         $this->fakeLocalVideoFile();
 
-        FFMpeg::openUrl('https://raw.githubusercontent.com/protonemedia/laravel-ffmpeg/master/tests/src/video.mp4')
+        FFMpeg::openUrl('https://ffmpeg.protone.media/video.mp4', [
+            'Authorization' => 'Basic YWRtaW46MTIzNA==',
+        ])
             ->export()
             ->inFormat($this->x264())
             ->save('new_video.mp4');

--- a/tests/MediaOpenerTest.php
+++ b/tests/MediaOpenerTest.php
@@ -126,7 +126,10 @@ class MediaOpenerTest extends TestCase
 
             $this->fail('Should have thrown 401 exception');
         } catch (RuntimeException $exception) {
-            $this->assertTrue(Str::contains($exception->getPrevious()->getMessage(), "HTTP error 401 Unauthorized"));
+            $this->assertTrue(
+                Str::contains($exception->getPrevious()->getMessage(), "HTTP error 401 Unauthorized"),
+                $exception->getPrevious()->getMessage()
+            );
         }
 
         $driver = FFMpeg::openUrl('https://ffmpeg.protone.media/video.mp4', [

--- a/tests/MediaOpenerTest.php
+++ b/tests/MediaOpenerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Disk;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaOnNetwork;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\TemporaryDirectories;
 use ProtoneMedia\LaravelFFMpeg\MediaOpener;
 use ProtoneMedia\LaravelFFMpeg\Support\FFMpeg;
@@ -98,6 +99,21 @@ class MediaOpenerTest extends TestCase
         TemporaryDirectories::deleteAll();
 
         $this->assertFileNotExists($tempPath);
+    }
+
+    /** @test */
+    public function it_can_open_a_remote_url_without_opening()
+    {
+        $mediaCollection = (new MediaOpener)
+            ->openUrl($url = 'https://raw.githubusercontent.com/protonemedia/laravel-ffmpeg/master/tests/src/guitar.m4a')
+            ->getDriver()
+            ->getMediaCollection();
+
+        $this->assertInstanceOf(MediaCollection::class, $mediaCollection);
+        $this->assertEquals(1, $mediaCollection->count());
+
+        $this->assertInstanceOf(MediaOnNetwork::class, $media = $mediaCollection->first());
+        $this->assertEquals($url, $media->getPath());
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,7 +44,7 @@ abstract class TestCase extends BaseTestCase
         Storage::extend('http', function ($app, $config) {
             return new FilesystemAdapter(
                 new FlysystemFilesystem(
-                    new HttpAdapter('https://raw.githubusercontent.com/pascalbaljetmedia/laravel-ffmpeg/master/tests/src/')
+                    new HttpAdapter('https://raw.githubusercontent.com/protonemedia/laravel-ffmpeg/master/tests/src/')
                 )
             );
         });


### PR DESCRIPTION
Without headers:

```php
FFMpeg::openUrl('https://videocoursebuilder.com/lesson-1.mp4');
```

With headers:

```php
FFMpeg::openUrl('https://videocoursebuilder.com/lesson-2.mp4', [
    'Authorization' => 'Basic YWRtaW46MTIzNA==',
]);
```

Multiple inputs with the same headers:

```php
FFMpeg::openUrl([
    'https://videocoursebuilder.com/lesson-3.mp4',
    'https://videocoursebuilder.com/lesson-4.mp4',
], [
    'Authorization' => 'Basic YWRtaW46MTIzNA==',
]);
```

Multiple inputs with different headers (`new` method for convenience):

```php
FFMpeg::new()
    ->openUrl('https://videocoursebuilder.com/lesson-5.mp4', [
        'Authorization' => 'Basic YWRtaW46MTIzNA==',
    ])
    ->openUrl('https://videocoursebuilder.com/lesson-6.mp4', [
        'Authorization' => 'Basic bmltZGE6NDMyMQ==',
    ])
```