### PR TITLE
V7: Watermark manipulation, Multiple filters per HLS format, dd() + resize() helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package provides an integration with FFmpeg for Laravel 6.0 and higher. [La
 * Compatible with Laravel 6.0 and higher, support for [Package Discovery](https://laravel.com/docs/7.0/packages#package-discovery).
 * Built-in support for HLS.
 * Built-in support for concatenation, multiple inputs/outputs, image sequences (timelapse), complex filters (and mapping), frame/thumbnail exports.
+* Built-in support for watermarks (positioning and manipulation).
 * PHP 7.2 and higher.
 
 ## Video Course Builder
@@ -160,6 +161,17 @@ FFMpeg::fromDisk('videos')
     ->save('small_steve.mkv');
 ```
 
+#### Resizing
+
+Since resizing is a common operation, we've added a dedicated method for it:
+
+```php
+FFMpeg::open('steve_howe.mp4')
+    ->export()
+    ->resize(640, 480);
+```
+The first argument is the width, and the second argument the height. The optional third argument is the mode. You can choose between `fit` (default), `inset`, `width` or `height`. You can find about these modes in the `FFMpeg\Filters\Video\ResizeFilter` class.
+
 ### Custom filters
 
 Sometimes you don't want to use the built-in filters. You can apply your own filter by providing a set of options. This can be an array or multiple strings as arguments:
@@ -233,6 +245,30 @@ $watermark->openUrl('https://videocoursebuilder.com/logo.png', [
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
 });
 ```
+
+#### Watermark manipulation
+
+This package can manipulate watermarks by using [Spatie's Image package](https://github.com/spatie/image). To get started, install the package with Composer:
+
+```bash
+composer require spatie/image
+```
+
+Now you can chain one more manipulation methods on the `WatermarkFactory` instance:
+
+```php
+FFMpeg::open('steve_howe.mp4')
+    ->addWatermark(function(WatermarkFactory $watermark) {
+        $watermark->open('logo.png')
+            ->right(25)
+            ->bottom(25)
+            ->width(100)
+            ->height(100)
+            ->greyscale();
+    });
+```
+
+Check out [the documentation](https://spatie.be/docs/image/v1/introduction) for all available methods.
 
 ### Export without transcoding
 

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0",
+        "spatie/image": "^1.7",
         "twistor/flysystem-http": "^0.2.0"
     },
     "autoload": {

--- a/src/Drivers/InteractsWithFilters.php
+++ b/src/Drivers/InteractsWithFilters.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\Drivers;
+
+use Closure;
+use FFMpeg\Coordinate\Dimension;
+use FFMpeg\Filters\Audio\SimpleFilter;
+use FFMpeg\Filters\FilterInterface;
+use FFMpeg\Filters\Video\ResizeFilter;
+use Illuminate\Support\Collection;
+use ProtoneMedia\LaravelFFMpeg\Exporters\MediaExporter;
+use ProtoneMedia\LaravelFFMpeg\FFMpeg\LegacyFilterMapping;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
+use ProtoneMedia\LaravelFFMpeg\Filters\WatermarkFactory;
+
+trait InteractsWithFilters
+{
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    protected $pendingComplexFilters;
+
+    /**
+     * Returns an array with the filters applied to the underlying media object.
+     *
+     * @return array
+     */
+    public function getFilters(): array
+    {
+        return iterator_to_array($this->media->getFiltersCollection());
+    }
+
+    /**
+     * Helper method to provide multiple ways to add a filter to the underlying
+     * media object.
+     *
+     * @return self
+     */
+    public function addFilter(): self
+    {
+        $arguments = func_get_args();
+
+        // to support '[in]filter[out]' complex filters
+        if ($this->isAdvancedMedia() && count($arguments) === 3) {
+            $this->media->filters()->custom(...$arguments);
+
+            return $this;
+        }
+
+        // use a callback to add a filter
+        if ($arguments[0] instanceof Closure) {
+            call_user_func_array($arguments[0], [$this->media->filters()]);
+
+            return $this;
+        }
+
+        // use an object to add a filter
+        if ($arguments[0] instanceof FilterInterface) {
+            call_user_func_array([$this->media, 'addFilter'], $arguments);
+
+            return $this;
+        }
+
+        // use a single array with parameters to define a filter
+        if (is_array($arguments[0])) {
+            $this->media->addFilter(new SimpleFilter($arguments[0]));
+
+            return $this;
+        }
+
+        // use all function arguments as a filter
+        $this->media->addFilter(new SimpleFilter($arguments));
+
+        return $this;
+    }
+
+    /**
+     * Calls the callable with a WatermarkFactory instance and
+     * adds the freshly generated WatermarkFilter.
+     *
+     * @param callable $withWatermarkFactory
+     * @return self
+     */
+    public function addWatermark(callable $withWatermarkFactory): self
+    {
+        $withWatermarkFactory(
+            $watermarkFactory = new WatermarkFactory
+        );
+
+        return $this->addFilter($watermarkFactory->get());
+    }
+
+    /**
+     * Shortcut for adding a Resize filter.
+     *
+     * @param int $width
+     * @param int $height
+     * @param string $mode
+     * @return self
+     */
+    public function resize($width, $height, $mode = ResizeFilter::RESIZEMODE_FIT): self
+    {
+        $dimension = new Dimension($width, $height);
+
+        $filter = new ResizeFilter($dimension, $mode);
+
+        return $this->addFilter($filter);
+    }
+
+    /**
+     * Maps the arguments into a 'LegacyFilterMapping' instance and
+     * pushed it to the 'pendingComplexFilters' collection. These
+     * filters will be applied later on by the MediaExporter.
+     */
+    public function addFilterAsComplexFilter($in, $out, ...$arguments): self
+    {
+        $this->pendingComplexFilters->push(new LegacyFilterMapping(
+            $in,
+            $out,
+            ...$arguments
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Getter for the pending complex filters.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getPendingComplexFilters(): Collection
+    {
+        return $this->pendingComplexFilters;
+    }
+}

--- a/src/Drivers/InteractsWithMediaStreams.php
+++ b/src/Drivers/InteractsWithMediaStreams.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\Drivers;
+
+use FFMpeg\FFProbe\DataMapping\Stream;
+use Illuminate\Support\Arr;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
+use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
+
+trait InteractsWithMediaStreams
+{
+    /**
+     * Returns an array with all streams.
+     *
+     * @return array
+     */
+    public function getStreams(): array
+    {
+        if (!$this->isAdvancedMedia()) {
+            return iterator_to_array($this->media->getStreams());
+        }
+
+        return $this->mediaCollection->map(function (Media $media) {
+            return $this->fresh()->open(MediaCollection::make([$media]))->getStreams();
+        })->collapse()->all();
+    }
+
+    /**
+     * Gets the duration of the media from the first stream or from the format.
+     */
+    public function getDurationInMiliseconds(): int
+    {
+        $stream = Arr::first($this->getStreams());
+
+        if ($stream->has('duration')) {
+            return $stream->get('duration') * 1000;
+        }
+
+        $format = $this->getFormat();
+
+        if ($format->has('duration')) {
+            return $format->get('duration') * 1000;
+        }
+    }
+
+    public function getDurationInSeconds(): int
+    {
+        return round($this->getDurationInMiliseconds() / 1000);
+    }
+
+    /**
+     * Gets the first audio streams of the media.
+     */
+    public function getAudioStream(): ?Stream
+    {
+        return Arr::first($this->getStreams(), function (Stream $stream) {
+            return $stream->isAudio();
+        });
+    }
+
+    /**
+     * Gets the first video streams of the media.
+     */
+    public function getVideoStream(): ?Stream
+    {
+        return Arr::first($this->getStreams(), function (Stream $stream) {
+            return $stream->isVideo();
+        });
+    }
+}

--- a/src/Drivers/PHPFFMpeg.php
+++ b/src/Drivers/PHPFFMpeg.php
@@ -4,11 +4,13 @@ namespace ProtoneMedia\LaravelFFMpeg\Drivers;
 
 use Closure;
 use Exception;
+use FFMpeg\Coordinate\Dimension;
 use FFMpeg\Coordinate\TimeCode;
 use FFMpeg\FFMpeg;
 use FFMpeg\FFProbe\DataMapping\Stream;
 use FFMpeg\Filters\Audio\SimpleFilter;
 use FFMpeg\Filters\FilterInterface;
+use FFMpeg\Filters\Video\ResizeFilter;
 use FFMpeg\Media\AbstractMediaType;
 use FFMpeg\Media\AdvancedMedia as BaseAdvancedMedia;
 use FFMpeg\Media\Concat;
@@ -285,15 +287,28 @@ class PHPFFMpeg
      */
     public function addWatermark(callable $withWatermarkFactory): self
     {
-        $watermarkFactory = new WatermarkFactory;
+        $withWatermarkFactory(
+            $watermarkFactory = new WatermarkFactory
+        );
 
-        $withWatermarkFactory($watermarkFactory);
+        return $this->addFilter($watermarkFactory->get());
+    }
 
-        $watermarkFilter = $watermarkFactory->get();
+    /**
+     * Shortcut for adding a Resize filter.
+     *
+     * @param int $width
+     * @param int $height
+     * @param string $mode
+     * @return self
+     */
+    public function resize($width, $height, $mode = ResizeFilter::RESIZEMODE_FIT): self
+    {
+        $dimension = new Dimension($width, $height);
 
-        $this->addFilter($watermarkFilter);
+        $filter = new ResizeFilter($dimension, $mode);
 
-        return $this;
+        return $this->addFilter($filter);
     }
 
     /**

--- a/src/Exporters/HLSExporter.php
+++ b/src/Exporters/HLSExporter.php
@@ -10,6 +10,7 @@ use FFMpeg\Format\VideoInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Disk;
+use ProtoneMedia\LaravelFFMpeg\Filters\WatermarkFactory;
 use ProtoneMedia\LaravelFFMpeg\MediaOpener;
 
 class HLSExporter extends MediaExporter
@@ -138,6 +139,13 @@ class HLSExporter extends MediaExporter
                 $this->driver->addFilterAsComplexFilter('[0]', "[v{$this->key}]", ...$arguments);
 
                 $this->called['called'] = true;
+            }
+
+            public function addWatermark(callable $withWatermarkFactory)
+            {
+                $withWatermarkFactory($watermarkFactory = new WatermarkFactory);
+
+                $this->addLegacyFilter($watermarkFactory->get());
             }
 
             public function scale($width, $height)

--- a/src/Exporters/HLSVideoFilters.php
+++ b/src/Exporters/HLSVideoFilters.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace ProtoneMedia\LaravelFFMpeg\Exporters;
+
+use FFMpeg\Coordinate\Dimension;
+use FFMpeg\Filters\AdvancedMedia\ComplexFilters;
+use FFMpeg\Filters\Video\ResizeFilter;
+use Illuminate\Support\Str;
+use ProtoneMedia\LaravelFFMpeg\Drivers\PHPFFMpeg;
+use ProtoneMedia\LaravelFFMpeg\Filters\WatermarkFactory;
+
+class HLSVideoFilters
+{
+    const MAPPING_GLUE = "_hls_";
+
+    /**
+     * @var \ProtoneMedia\LaravelFFMpeg\Drivers\PHPFFMpeg
+     */
+    private $driver;
+
+    /**
+     * Key of the video in the HLS export.
+     *
+     * @var int
+     */
+    private $formatKey;
+
+    /**
+     * Number of filters added to this video.
+     *
+     * @var integer
+     */
+    private $filterCount = 0;
+
+    public function __construct(PHPFFMpeg $driver, int $formatKey)
+    {
+        $this->driver    = $driver;
+        $this->formatKey = $formatKey;
+    }
+
+    public function count(): int
+    {
+        return $this->filterCount;
+    }
+
+    private function increaseFilterCount(): self
+    {
+        $this->filterCount++;
+
+        return $this;
+    }
+
+    /**
+     * Generates an input mapping for a new filter.
+     *
+     * @return string
+     */
+    private function input(): string
+    {
+        return $this->filterCount ? static::glue($this->formatKey, $this->filterCount) : '[0]';
+    }
+
+    /**
+     * Generates an output mapping for a new filter.
+     *
+     * @return string
+     */
+    private function output(): string
+    {
+        return static::glue($this->formatKey, $this->filterCount + 1);
+    }
+
+    /**
+     * Adds a filter as a complex filter.
+     */
+    public function addLegacyFilter(...$arguments): self
+    {
+        $this->driver->addFilterAsComplexFilter($this->input(), $this->output(), ...$arguments);
+
+        return $this->increaseFilterCount();
+    }
+
+    /**
+     * Shortcut for the ResizeFilter.
+     *
+     * @param int $width
+     * @param int $height
+     * @param string $mode
+     * @return self
+     */
+    public function resize($width, $height, $mode = null): self
+    {
+        $dimension = new Dimension($width, $height);
+
+        $filter = new ResizeFilter($dimension, $mode);
+
+        return $this->addLegacyFilter($filter);
+    }
+
+    /**
+     * Shortcut for the WatermarkFactory.
+     *
+     * @param callable $withWatermarkFactory
+     * @return self
+     */
+    public function addWatermark(callable $withWatermarkFactory): self
+    {
+        $withWatermarkFactory($watermarkFactory = new WatermarkFactory);
+
+        return $this->addLegacyFilter($watermarkFactory->get());
+    }
+
+    /**
+     * Adds a scale filter to the video, will be replaced in favor of resize().
+     *
+     * @param int $width
+     * @param int $height
+     * @deprecated 7.4.0
+     * @return self
+     */
+    public function scale($width, $height): self
+    {
+        return $this->addFilter("scale={$width}:{$height}");
+    }
+
+    /**
+     * Adds a filter object or a callable to the driver and automatically
+     * chooses the right input and output mapping.
+     */
+    public function addFilter(...$arguments): self
+    {
+        if (count($arguments) === 1 && !is_callable($arguments[0])) {
+            $this->driver->addFilter($this->input(), $arguments[0], $this->output());
+        } else {
+            $this->driver->addFilter(function (ComplexFilters $filters) use ($arguments) {
+                $arguments[0]($filters, $this->input(), $this->output());
+            });
+        }
+
+        return $this->increaseFilterCount();
+    }
+
+    public static function glue($format, $filter): string
+    {
+        return "[v{$format}" . static::MAPPING_GLUE . "{$filter}]";
+    }
+
+    public static function beforeGlue($input): string
+    {
+        return Str::before($input, static::MAPPING_GLUE);
+    }
+};

--- a/src/Exporters/MediaExporter.php
+++ b/src/Exporters/MediaExporter.php
@@ -92,6 +92,11 @@ class MediaExporter
         );
     }
 
+    public function dd(string $path = null)
+    {
+        dd($this->getCommand($path));
+    }
+
     public function save(string $path = null)
     {
         $outputMedia = $path ? $this->getDisk()->makeMedia($path) : null;

--- a/src/FFMpeg/AdvancedOutputMapping.php
+++ b/src/FFMpeg/AdvancedOutputMapping.php
@@ -5,7 +5,8 @@ namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
 use FFMpeg\Format\FormatInterface;
 use FFMpeg\Format\Video\DefaultVideo;
 use FFMpeg\Media\AdvancedMedia;
-use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use ProtoneMedia\LaravelFFMpeg\Exporters\HLSExporter;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 
 class AdvancedOutputMapping
@@ -75,18 +76,8 @@ class AdvancedOutputMapping
 
     public function hasOut(string $out): bool
     {
-        if (Str::contains($out, '.')) {
-            $out = Str::before($out, '.');
-        }
-
-        $outs = collect($this->outs)->map(function ($out) {
-            if (Str::contains($out, '.')) {
-                $out = Str::before($out, '.');
-            }
-
-            return $out;
-        })->all();
-
-        return in_array($out, $outs);
+        return Collection::make($this->outs)->map(function ($out) {
+            return HLSExporter::beforeGlue($out);
+        })->contains(HLSExporter::beforeGlue($out));
     }
 }

--- a/src/FFMpeg/AdvancedOutputMapping.php
+++ b/src/FFMpeg/AdvancedOutputMapping.php
@@ -5,6 +5,7 @@ namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
 use FFMpeg\Format\FormatInterface;
 use FFMpeg\Format\Video\DefaultVideo;
 use FFMpeg\Media\AdvancedMedia;
+use Illuminate\Support\Str;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 
 class AdvancedOutputMapping
@@ -74,6 +75,18 @@ class AdvancedOutputMapping
 
     public function hasOut(string $out): bool
     {
-        return in_array($out, $this->outs);
+        if (Str::contains($out, '.')) {
+            $out = Str::before($out, '.');
+        }
+
+        $outs = collect($this->outs)->map(function ($out) {
+            if (Str::contains($out, '.')) {
+                $out = Str::before($out, '.');
+            }
+
+            return $out;
+        })->all();
+
+        return in_array($out, $outs);
     }
 }

--- a/src/FFMpeg/AdvancedOutputMapping.php
+++ b/src/FFMpeg/AdvancedOutputMapping.php
@@ -6,7 +6,7 @@ use FFMpeg\Format\FormatInterface;
 use FFMpeg\Format\Video\DefaultVideo;
 use FFMpeg\Media\AdvancedMedia;
 use Illuminate\Support\Collection;
-use ProtoneMedia\LaravelFFMpeg\Exporters\HLSExporter;
+use ProtoneMedia\LaravelFFMpeg\Exporters\HLSVideoFilters;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\Media;
 
 class AdvancedOutputMapping
@@ -76,8 +76,10 @@ class AdvancedOutputMapping
 
     public function hasOut(string $out): bool
     {
-        return Collection::make($this->outs)->map(function ($out) {
-            return HLSExporter::beforeGlue($out);
-        })->contains(HLSExporter::beforeGlue($out));
+        return Collection::make($this->outs)
+            ->map(function ($out) {
+                return HLSVideoFilters::beforeGlue($out);
+            })
+            ->contains(HLSVideoFilters::beforeGlue($out));
     }
 }

--- a/src/FFMpeg/LegacyFilterMapping.php
+++ b/src/FFMpeg/LegacyFilterMapping.php
@@ -5,7 +5,7 @@ namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use ProtoneMedia\LaravelFFMpeg\Drivers\PHPFFMpeg;
-use ProtoneMedia\LaravelFFMpeg\Exporters\HLSExporter;
+use ProtoneMedia\LaravelFFMpeg\Exporters\HLSVideoFilters;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
 
 class LegacyFilterMapping
@@ -30,7 +30,7 @@ class LegacyFilterMapping
      */
     public function normalizeIn(): int
     {
-        return preg_replace("/[^0-9]/", "", HLSExporter::beforeGlue($this->in));
+        return preg_replace("/[^0-9]/", "", HLSVideoFilters::beforeGlue($this->in));
     }
 
     /**

--- a/src/FFMpeg/LegacyFilterMapping.php
+++ b/src/FFMpeg/LegacyFilterMapping.php
@@ -5,6 +5,7 @@ namespace ProtoneMedia\LaravelFFMpeg\FFMpeg;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use ProtoneMedia\LaravelFFMpeg\Drivers\PHPFFMpeg;
+use ProtoneMedia\LaravelFFMpeg\Exporters\HLSExporter;
 use ProtoneMedia\LaravelFFMpeg\Filesystem\MediaCollection;
 
 class LegacyFilterMapping
@@ -29,7 +30,7 @@ class LegacyFilterMapping
      */
     public function normalizeIn(): int
     {
-        return preg_replace("/[^0-9]/", "", $this->in);
+        return preg_replace("/[^0-9]/", "", HLSExporter::beforeGlue($this->in));
     }
 
     /**

--- a/tests/AddFilterTest.php
+++ b/tests/AddFilterTest.php
@@ -4,6 +4,7 @@ namespace ProtoneMedia\LaravelFFMpeg\Tests;
 
 use FFMpeg\Filters\AdvancedMedia\ComplexFilters;
 use FFMpeg\Filters\Audio\SimpleFilter;
+use FFMpeg\Filters\Video\ResizeFilter;
 use FFMpeg\Filters\Video\VideoFilters;
 use FFMpeg\Filters\Video\WatermarkFilter;
 use FFMpeg\Format\AudioInterface;
@@ -34,7 +35,20 @@ class AddFilter extends TestCase
     }
 
     /** @test */
-    public function it_can_add_a_watermark_with_the_factory_helper()
+    public function it_can_resize_the_video_by_using_the_resize_method()
+    {
+        $this->fakeLocalVideoFile();
+
+        $media = (new MediaOpener)->open('video.mp4')->resize(640, 360);
+
+        $this->assertCount(1, $media->getFilters());
+        $this->assertInstanceOf(ResizeFilter::class, $filter = $media->getFilters()[0]);
+        $this->assertEquals(640, $filter->getDimension()->getWidth());
+        $this->assertEquals(360, $filter->getDimension()->getHeight());
+    }
+
+    /** @test */
+    public function it_can_add_a_watermark_with_the_factory_helper_and_manipulate_it()
     {
         $this->fakeLocalVideoFile();
         $this->addTestFile('logo.png');
@@ -44,7 +58,11 @@ class AddFilter extends TestCase
         $this->assertCount(0, $media->getFilters());
 
         $media->addWatermark(function (WatermarkFactory $watermark) {
-            $watermark->open('logo.png');
+            $watermark->open('logo.png')
+                ->greyscale()
+                ->width(100)
+                ->bottom()
+                ->left();
         });
 
         $this->assertCount(1, $media->getFilters());

--- a/tests/HlsExportTest.php
+++ b/tests/HlsExportTest.php
@@ -6,6 +6,7 @@ use FFMpeg\Filters\AdvancedMedia\ComplexFilters;
 use FFMpeg\Filters\Video\VideoFilters;
 use Illuminate\Support\Facades\Storage;
 use ProtoneMedia\LaravelFFMpeg\Exporters\HLSPlaylistGenerator;
+use ProtoneMedia\LaravelFFMpeg\Exporters\HLSVideoFilters;
 use ProtoneMedia\LaravelFFMpeg\Filters\WatermarkFactory;
 use ProtoneMedia\LaravelFFMpeg\MediaOpener;
 
@@ -172,7 +173,7 @@ class HlsExportTest extends TestCase
         (new MediaOpener)
             ->open('video.mp4')
             ->exportForHLS()
-            ->addFormat($lowBitrate, function ($media) {
+            ->addFormat($lowBitrate, function (HLSVideoFilters $media) {
                 $media->scale(640, 360);
             })
             ->addFormat($midBitrate, function ($media) {

--- a/tests/HlsExportTest.php
+++ b/tests/HlsExportTest.php
@@ -6,6 +6,7 @@ use FFMpeg\Filters\AdvancedMedia\ComplexFilters;
 use FFMpeg\Filters\Video\VideoFilters;
 use Illuminate\Support\Facades\Storage;
 use ProtoneMedia\LaravelFFMpeg\Exporters\HLSPlaylistGenerator;
+use ProtoneMedia\LaravelFFMpeg\Filters\WatermarkFactory;
 use ProtoneMedia\LaravelFFMpeg\MediaOpener;
 
 class HlsExportTest extends TestCase
@@ -161,6 +162,7 @@ class HlsExportTest extends TestCase
     public function it_can_export_to_hls_with_legacy_filters_for_each_format()
     {
         $this->fakeLocalVideoFile();
+        $this->addTestFile('logo.png');
 
         $lowBitrate   = $this->x264()->setKiloBitrate(250);
         $midBitrate   = $this->x264()->setKiloBitrate(500);
@@ -179,6 +181,10 @@ class HlsExportTest extends TestCase
                 $media->addLegacyFilter(function ($filters) {
                     $filters->resize(new \FFMpeg\Coordinate\Dimension(1280, 960));
                 });
+
+                // $media->addWatermark(function (WatermarkFactory $factory) {
+                //     $factory->open("logo.png");
+                // });
             })
             ->addFormat($highBitrate)
             ->addFormat($superBitrate, function ($media) {

--- a/tests/HlsExportTest.php
+++ b/tests/HlsExportTest.php
@@ -173,18 +173,12 @@ class HlsExportTest extends TestCase
             ->open('video.mp4')
             ->exportForHLS()
             ->addFormat($lowBitrate, function ($media) {
-                $media->addLegacyFilter(function (VideoFilters $filters) {
-                    $filters->resize(new \FFMpeg\Coordinate\Dimension(640, 480));
-                });
+                $media->scale(640, 360);
             })
             ->addFormat($midBitrate, function ($media) {
-                $media->addLegacyFilter(function ($filters) {
-                    $filters->resize(new \FFMpeg\Coordinate\Dimension(1280, 960));
-                });
-
-                // $media->addWatermark(function (WatermarkFactory $factory) {
-                //     $factory->open("logo.png");
-                // });
+                $media->addWatermark(function (WatermarkFactory $factory) {
+                    $factory->open("logo.png");
+                })->resize(1280, 960);
             })
             ->addFormat($highBitrate)
             ->addFormat($superBitrate, function ($media) {

--- a/tests/WatermarkFactoryTest.php
+++ b/tests/WatermarkFactoryTest.php
@@ -98,4 +98,25 @@ class WatermarkFactoryTest extends TestCase
 
         $this->assertStringContainsString("overlay=W-w+50:H-h+25", $this->getSecondCommand($factory));
     }
+
+    /** @test */
+    public function it_can_manipulate_the_watermark_image()
+    {
+        $factory = new WatermarkFactory;
+
+        $factory->open('logo.png')
+            ->width(100)
+            ->bottom(25)
+            ->left(25);
+
+        $command = $this->getSecondCommand($factory);
+
+        $this->assertStringContainsString(sys_get_temp_dir(), $command);
+
+        $path = $factory->getPath();
+
+        [$width] = getimagesize($path);
+
+        $this->assertEquals(100, $width);
+    }
 }


### PR DESCRIPTION
Watermark manipulations:
```php
FFMpeg::fromDisk('videos')
    ->open('video.mp4')
    ->addWatermark(function(WatermarkFactory $watermark) {
        $watermark->open('logo.png')
            ->width(100)
            ->height(100)
            ->greyscale();
    });
```

Dump and die:
```php
FFMpeg::fromDisk('videos')
    ->open('video.mp4')
    ->export()
    ->inFormat(new X264)
    ->dd('output.mkv');
```

Resize filter shortcut:
```php
FFMpeg::fromDisk('videos')
    ->open('video.mp4')
    ->resize(640, 360);
```

HLS export with multiple filters per format:
```php
FFMpeg::open('video.mp4')
    ->exportForHLS()
    ->addFormat($lowBitrate, function ($filters) {
        $filters->addWatermark(function ($watermark) {
            $watermark->open("logo.png")
                ->top(15)
                ->left(15)
                ->width(100)
                ->height(100);
        });

        $filters->resize(640, 360);
    })
    ->addFormat($highBitrate, function ($filters) {
        $filters->addWatermark(function ($watermark) {
            $watermark->open("logo.png")
                ->top(30)
                ->left(30)
                ->width(200)
                ->height(200);
        });

        $filters->resize(1280, 720);
    })
    ->toDisk('local')
    ->save('adaptive.m3u8');
```