### PR TITLE
[feature/bugfix] InteractsWithFilters - respect forceStandards

### DIFF
--- a/src/Drivers/InteractsWithFilters.php
+++ b/src/Drivers/InteractsWithFilters.php
@@ -98,11 +98,11 @@ trait InteractsWithFilters
      * @param string $mode
      * @return self
      */
-    public function resize($width, $height, $mode = ResizeFilter::RESIZEMODE_FIT): self
+    public function resize($width, $height, $mode = ResizeFilter::RESIZEMODE_FIT, $forceStandards = true): self
     {
         $dimension = new Dimension($width, $height);
 
-        $filter = new ResizeFilter($dimension, $mode);
+        $filter = new ResizeFilter($dimension, $mode, $forceStandards);
 
         return $this->addFilter($filter);
     }


### PR DESCRIPTION
Stucked in a issue, that a re-calculated height / width was not as espected.

In the Php ffmpeg inside the ResizeFilter class, there is also the possibility to ignore
video standards. so my own calcs can now done.