### PR TITLE
Fix HLS key rotation condition

### DIFF
--- a/src/Exporters/EncryptsHLSSegments.php
+++ b/src/Exporters/EncryptsHLSSegments.php
@@ -166,10 +166,12 @@ trait EncryptsHLSSegments
         );
 
         // prepare for the next round
-        $this->nextEncryptionFilenameAndKey = [
-            static::generateEncryptionKeyFilename(),
-            static::generateEncryptionKey(),
-        ];
+        if ($this->rotateEncryptiongKey) {
+            $this->nextEncryptionFilenameAndKey = [
+                static::generateEncryptionKeyFilename(),
+                static::generateEncryptionKey(),
+            ];
+        }
 
         // call the callback
         if ($this->onNewEncryptionKey) {

--- a/tests/EncryptedHlsExportTest.php
+++ b/tests/EncryptedHlsExportTest.php
@@ -29,22 +29,27 @@ class EncryptedHlsExportTest extends TestCase
     {
         $this->fakeLocalVideoFile();
 
-        $lowBitrate = $this->x264()->setKiloBitrate(250);
+        $lowBitrate  = $this->x264()->setKiloBitrate(250);
+        $highBitrate = $this->x264()->setKiloBitrate(500);
 
         FFMpeg::open('video.mp4')
             ->exportForHLS()
             ->withEncryptionKey(HLSExporter::generateEncryptionKey())
             ->addFormat($lowBitrate)
+            ->addFormat($highBitrate)
             ->addListener($listener = new StdListener)
             ->save('adaptive.m3u8');
 
         $this->assertTrue(Storage::disk('local')->has('adaptive.m3u8'));
         $this->assertTrue(Storage::disk('local')->has('adaptive_0_250.m3u8'));
+        $this->assertTrue(Storage::disk('local')->has('adaptive_1_500.m3u8'));
 
         $this->assertPlaylistPattern(Storage::disk('local')->get('adaptive.m3u8'), [
             '#EXTM3U',
             HlsExportTest::streamInfoPattern('1920x1080'),
             'adaptive_0_250.m3u8',
+            HlsExportTest::streamInfoPattern('1920x1080'),
+            'adaptive_1_500.m3u8',
             '#EXT-X-ENDLIST',
         ], $listener);
 


### PR DESCRIPTION
Fix for #302, disables key rotation when withRotatingEncryptionKey() is not called.