### PR TITLE
Update README.md with a working resize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Since resizing is a common operation, we've added a dedicated method for it:
 ```php
 FFMpeg::open('steve_howe.mp4')
     ->export()
-    ->resize(640, 480);
+    ->inFormat(new \FFMpeg\Format\Video\X264)
+    ->resize(640, 480)
+    ->save('steve_howe_resized.mp4');
 ```
 The first argument is the width, and the second argument the height. The optional third argument is the mode. You can choose between `fit` (default), `inset`, `width` or `height`. The optional fourth argument is a boolean whether or not to force the use of standards ratios. You can find about these modes in the `FFMpeg\Filters\Video\ResizeFilter` class.
 


### PR DESCRIPTION
The resize example as demonstrated would fail because was expecting VideoInterface to be set before call:

```
TypeError
FFMpeg\Filters\Video\ResizeFilter::apply(): Argument #2 ($format) must be of type FFMpeg\Format\VideoInterface, ProtoneMedia\LaravelFFMpeg\FFMpeg\NullFormat given, called in /var/www/html/vendor/php-ffmpeg/php-ffmpeg/src/FFMpeg/Media/AbstractVideo.php on line 161
```
Just updated the example to a cut-and-pastable working sample