### PR TITLE
Update README.md - Custom segment format fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,8 +654,8 @@ FFMpeg::fromDisk('videos')
     ->open('steve_howe.mp4')
     ->exportForHLS()
     ->useSegmentFilenameGenerator(function ($name, $format, $key, callable $segments, callable $playlist) {
-        $segments("{$name}-{$format}-{$key}-%03d.ts");
-        $playlist("{$name}-{$format}-{$key}.m3u8");
+        $segments("{$name}-{$format->getKiloBitrate()}-{$key}-%03d.ts");
+        $playlist("{$name}-{$format->getKiloBitrate()}-{$key}.m3u8");
     });
 ```
 


### PR DESCRIPTION
Custom segment format returns array, needs to be a string.

Default generator in [HLSExporter.php](https://github.com/protonemedia/laravel-ffmpeg/blob/5e80a8172a35f154b649758f93d7c5b3da7889d8/src/Exporters/HLSExporter.php#L109)
```
/**
     * Returns a default generator if none is set.
     *
     * @return callable
     */
    private function getSegmentFilenameGenerator(): callable
    {
        return $this->segmentFilenameGenerator ?: function ($name, $format, $key, $segments, $playlist) {
            $segments("{$name}_{$key}_{$format->getKiloBitrate()}_%05d.ts");
            $playlist("{$name}_{$key}_{$format->getKiloBitrate()}.m3u8");
        };
    }
```