### PR TITLE
[fix] php 8.x avoid Implicit conversion from float

### DIFF
--- a/src/Drivers/InteractsWithMediaStreams.php
+++ b/src/Drivers/InteractsWithMediaStreams.php
@@ -33,13 +33,13 @@ trait InteractsWithMediaStreams
         $stream = Arr::first($this->getStreams());
 
         if ($stream->has('duration')) {
-            return $stream->get('duration') * 1000;
+            return intval(round($stream->get('duration') * 1000));
         }
 
         $format = $this->getFormat();
 
         if ($format->has('duration')) {
-            return $format->get('duration') * 1000;
+            return intval(round($stream->get('duration') * 1000));
         }
     }
 


### PR DESCRIPTION
as typehinted as integer.
only round delivers double - and only intval has rounding errors (cause of intval is cutting).
so both methods :-)

on line 48 there is a round method. 
may this also can intval-ed ?