### PR TITLE
[fix] php8.x avoid implicit conversion errors

### DIFF
--- a/src/Drivers/InteractsWithMediaStreams.php
+++ b/src/Drivers/InteractsWithMediaStreams.php
@@ -33,13 +33,13 @@ trait InteractsWithMediaStreams
         $stream = Arr::first($this->getStreams());
 
         if ($stream->has('duration')) {
-            return $stream->get('duration') * 1000;
+            return intval(round($stream->get('duration') * 1000));
         }
 
         $format = $this->getFormat();
 
         if ($format->has('duration')) {
-            return $format->get('duration') * 1000;
+            return intval(round($format->get('duration') * 1000));
         }
     }
 


### PR DESCRIPTION
round delivers double. ant intval alone cuts the calculation.
so both together :-)