### PR TITLE
Use seconds as float format

### DIFF
--- a/src/Drivers/InteractsWithMediaStreams.php
+++ b/src/Drivers/InteractsWithMediaStreams.php
@@ -28,7 +28,7 @@ trait InteractsWithMediaStreams
     /**
      * Gets the duration of the media from the first stream or from the format.
      */
-    public function getDurationInMiliseconds(): int
+    public function getDurationInMiliseconds(): float
     {
         $stream = Arr::first($this->getStreams());
 
@@ -43,9 +43,9 @@ trait InteractsWithMediaStreams
         }
     }
 
-    public function getDurationInSeconds(): int
+    public function getDurationInSeconds(): float
     {
-        return round($this->getDurationInMiliseconds() / 1000);
+        return $this->getDurationInMiliseconds() / 1000;
     }
 
     /**

--- a/src/Exporters/VTTPreviewThumbnailsGenerator.php
+++ b/src/Exporters/VTTPreviewThumbnailsGenerator.php
@@ -9,10 +9,10 @@ use ProtoneMedia\LaravelFFMpeg\Filters\TileFilter;
 class VTTPreviewThumbnailsGenerator
 {
     private TileFilter $tileFilter;
-    private int $durationInSeconds;
+    private float $durationInSeconds;
     private Closure $sequenceFilenameResolver;
 
-    public function __construct(TileFilter $tileFilter, int $durationInSeconds, Closure $sequenceFilenameResolver)
+    public function __construct(TileFilter $tileFilter, float $durationInSeconds, Closure $sequenceFilenameResolver)
     {
         $this->tileFilter               = $tileFilter;
         $this->durationInSeconds        = $durationInSeconds;


### PR DESCRIPTION
I'm probing media files using  `getDurationInSeconds()`, however it doesn't return the correct timestamp.

Dashjs shows the correct timestamp `00:00:12`, this package `00:00:11`.

If a rounded number is really needed, I would use `ceil` instead of `round`, as this should correct the seconds number.

Thanks!
