### PR TITLE
hls errors if you pass audio only

### DIFF
--- a/src/Exporters/HLSExporter.php
+++ b/src/Exporters/HLSExporter.php
@@ -109,8 +109,12 @@ class HLSExporter extends MediaExporter
     private function getSegmentFilenameGenerator(): callable
     {
         return $this->segmentFilenameGenerator ?: function ($name, $format, $key, $segments, $playlist) {
-            $segments("{$name}_{$key}_{$format->getKiloBitrate()}_%05d.ts");
-            $playlist("{$name}_{$key}_{$format->getKiloBitrate()}.m3u8");
+            $bitrate = $this->driver->getVideoStream()
+                ? $format->getKiloBitrate()
+                : $format->getAudioKiloBitrate();
+
+            $segments("{$name}_{$key}_{$bitrate}_%05d.ts");
+            $playlist("{$name}_{$key}_{$bitrate}.m3u8");
         };
     }
 

--- a/src/Exporters/HLSPlaylistGenerator.php
+++ b/src/Exporters/HLSPlaylistGenerator.php
@@ -49,8 +49,10 @@ class HLSPlaylistGenerator implements PlaylistGenerator
             $media = (new MediaOpener($segmentPlaylist->getDisk(), $driver))
                 ->openWithInputOptions($segmentPlaylist->getPath(), ['-allowed_extensions', 'ALL']);
 
-            if ($frameRate = StreamParser::new($media->getVideoStream())->getFrameRate()) {
-                $streamInfoLine .= ",FRAME-RATE={$frameRate}";
+            if ($media->getVideoStream()) {
+                if ($frameRate = StreamParser::new($media->getVideoStream())->getFrameRate()) {
+                    $streamInfoLine .= ",FRAME-RATE={$frameRate}";
+                }
             }
 
             return [$streamInfoLine, $segmentPlaylist->getFilename()];

--- a/tests/HlsExportTest.php
+++ b/tests/HlsExportTest.php
@@ -40,7 +40,7 @@ class HlsExportTest extends TestCase
     }
 
     /** @test */
-    public function it_can_export_a_single_media_file_into_a_hls_export()
+    public function it_can_export_a_single_video_file_into_a_hls_export()
     {
         $this->fakeLocalVideoFile();
 
@@ -81,6 +81,41 @@ class HlsExportTest extends TestCase
             static::streamInfoPattern('1920x1080'),
             'adaptive_1_1000.m3u8',
             static::streamInfoPattern('1920x1080'),
+            'adaptive_2_4000.m3u8',
+            '#EXT-X-ENDLIST',
+        ]);
+    }
+
+    /** @test */
+    public function it_can_export_a_single_audio_file_into_a_hls_export()
+    {
+        $this->fakeLocalAudioFile();
+
+        $lowBitrate  = $this->x264()->setAudioKiloBitrate(250);
+        $midBitrate  = $this->x264()->setAudioKiloBitrate(1000);
+        $highBitrate = $this->x264()->setAudioKiloBitrate(4000);
+
+        (new MediaOpener)
+            ->open('guitar.m4a')
+            ->exportForHLS()
+            ->addFormat($lowBitrate)
+            ->addFormat($midBitrate)
+            ->addFormat($highBitrate)
+            ->toDisk('local')
+            ->save('adaptive.m3u8');
+
+        $this->assertTrue(Storage::disk('local')->has('adaptive.m3u8'));
+        $this->assertTrue(Storage::disk('local')->has('adaptive_0_250.m3u8'));
+        $this->assertTrue(Storage::disk('local')->has('adaptive_1_1000.m3u8'));
+        $this->assertTrue(Storage::disk('local')->has('adaptive_2_4000.m3u8'));
+
+        $this->assertPlaylistPattern(Storage::disk('local')->get('adaptive.m3u8'), [
+            '#EXTM3U',
+            '#EXT-X-STREAM-INF:BANDWIDTH=275000,CODECS="mp4a.40.34"',
+            'adaptive_0_250.m3u8',
+            '#EXT-X-STREAM-INF:BANDWIDTH=1100000,CODECS="mp4a.40.34"',
+            'adaptive_1_1000.m3u8',
+            '#EXT-X-STREAM-INF:BANDWIDTH=4400000,CODECS="mp4a.40.34"',
             'adaptive_2_4000.m3u8',
             '#EXT-X-ENDLIST',
         ]);


### PR DESCRIPTION
This solves the problem when you only want to generate hls from an mp3. 
Basically, MP3 doesn't have video, the code is as is, 
```
$low = (new X264)->setAudioKiloBitrate(96);
        $med = (new X264)->setAudioKiloBitrate(128);
        $high = (new X264)->setAudioKiloBitrate(256);
        $ultra = (new X264)->setAudioKiloBitrate(320);

        FFMpeg::fromDisk(config('filesystems.default'))
            ->open($storageLocation) // MP3 file
            ->exportForHLS()
            ->addFormat($low)
            ->addFormat($med)
            ->addFormat($high)
            ->addFormat($ultra)
            ->setSegmentLength(10)
            ->save($toLocation); //m3u8
```
take note, I am only passing an MP3 file, here, you can still specify the AudioKB 