### PR TITLE
fix: Remove EXT-X-ENDLIST from master playlist file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -58,7 +58,7 @@ jobs:
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}-dep-${{ matrix.dependency-version }}

--- a/src/Exporters/HLSExporter.php
+++ b/src/Exporters/HLSExporter.php
@@ -88,7 +88,23 @@ class HLSExporter extends MediaExporter
 
     private function getPlaylistGenerator(): PlaylistGenerator
     {
-        return $this->playlistGenerator ?: new HLSPlaylistGenerator();
+        return $this->playlistGenerator ??= new HLSPlaylistGenerator();
+    }
+
+    /**
+     * Method to not add the #EXT-X-ENDLIST line to the playlist.
+     *
+     * @return self
+     */
+    public function withoutPlaylistEndLine(): self
+    {
+        $playlistGenerator = $this->getPlaylistGenerator();
+
+        if ($playlistGenerator instanceof HLSPlaylistGenerator) {
+            $playlistGenerator->withoutEndLine();
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Exporters/HLSPlaylistGenerator.php
+++ b/src/Exporters/HLSPlaylistGenerator.php
@@ -12,7 +12,6 @@ use ProtoneMedia\LaravelFFMpeg\Support\StreamParser;
 class HLSPlaylistGenerator implements PlaylistGenerator
 {
     public const PLAYLIST_START = '#EXTM3U';
-    public const PLAYLIST_END   = '#EXT-X-ENDLIST';
 
     /**
      * Return the line from the master playlist that references the given segment playlist.
@@ -58,7 +57,6 @@ class HLSPlaylistGenerator implements PlaylistGenerator
             return [$streamInfoLine, $segmentPlaylist->getFilename()];
         })->collapse()
             ->prepend(static::PLAYLIST_START)
-            ->push(static::PLAYLIST_END)
             ->implode(PHP_EOL);
     }
 }

--- a/src/Exporters/HLSPlaylistGenerator.php
+++ b/src/Exporters/HLSPlaylistGenerator.php
@@ -12,6 +12,21 @@ use ProtoneMedia\LaravelFFMpeg\Support\StreamParser;
 class HLSPlaylistGenerator implements PlaylistGenerator
 {
     public const PLAYLIST_START = '#EXTM3U';
+    public const PLAYLIST_END   = '#EXT-X-ENDLIST';
+
+    protected bool $withEndLine = true;
+
+    /**
+     * Adds the #EXT-X-ENDLIST tag to the end of the playlist.
+     *
+     * @return $this
+     */
+    public function withoutEndLine(): self
+    {
+        $this->withEndLine = false;
+
+        return $this;
+    }
 
     /**
      * Return the line from the master playlist that references the given segment playlist.
@@ -57,6 +72,7 @@ class HLSPlaylistGenerator implements PlaylistGenerator
             return [$streamInfoLine, $segmentPlaylist->getFilename()];
         })->collapse()
             ->prepend(static::PLAYLIST_START)
+            ->when($this->withEndLine, fn (Collection $lines) => $lines->push(static::PLAYLIST_END))
             ->implode(PHP_EOL);
     }
 }


### PR DESCRIPTION
I am a contributor on the [shaka project](https://github.com/shaka-project/shaka-player) and noticed that playback was broken with this library. 
This PR fixes a bug in the master playlist and allows playback with shaka (and probably other players where playback previously failed).

Unlike the [EXTM3U ](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.1.1) element which is required at the start every Media Playlist and  every Master Playlist. The [EXT-X-ENDLIST](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.4) should only appear in a Media Playlist file.