### PR TITLE
Fix "Deprecated: Creation of dynamic property"

### DIFF
--- a/src/Http/DynamicHLSPlaylist.php
+++ b/src/Http/DynamicHLSPlaylist.php
@@ -36,6 +36,13 @@ class DynamicHLSPlaylist implements Responsable
     private $mediaResolver;
 
     /**
+     * Callable to retrieve the path to the given playlist.
+     *
+     * @var callable
+     */
+    private $playlistResolver;
+
+    /**
      * @var array
      */
     private $keyCache = [];


### PR DESCRIPTION
this will fix:
```
Deprecated: Creation of dynamic property DynamicHLSPlaylist::$playlistResolver is deprecated in file on line 94
```

https://php.watch/versions/8.2/dynamic-properties-deprecated